### PR TITLE
feat: disable sigcolumn when opening terminal

### DIFF
--- a/plugin/termim.lua
+++ b/plugin/termim.lua
@@ -9,6 +9,7 @@ vim.api.nvim_create_autocmd({ 'TermOpen' }, {
     callback = function(event)
         vim.cmd('setlocal nonumber')
         vim.cmd('setlocal norelativenumber')
+        vim.cmd('setlocal signcolumn=no')
         vim.cmd('startinsert!')
         vim.cmd('set cmdheight=1')
         vim.bo[event.buf].buflisted = false


### PR DESCRIPTION
Hi @2KAbhishek ,

I was ~~stealing~~ borrowing some code from termin and realized that it does not disable signals column.
Said feature has no use inside of terminal and can be disabled there saving on a little bit of space.

Before:
![image](https://github.com/sleeptightAnsiC/termim.nvim/assets/91839286/0dfbc998-eeed-4a06-9af2-571fb21f0bdc)


After:
![image](https://github.com/sleeptightAnsiC/termim.nvim/assets/91839286/99f94474-52ef-476d-904b-edb1a84ba7bb)
