### PR TITLE
fix: prevent 'startinsert' if terminal buffer hasn't been entered

### DIFF
--- a/plugin/termim.lua
+++ b/plugin/termim.lua
@@ -10,7 +10,7 @@ vim.api.nvim_create_autocmd({ 'TermOpen' }, {
         vim.cmd('setlocal nonumber')
         vim.cmd('setlocal norelativenumber')
         vim.cmd('setlocal signcolumn=no')
-        vim.cmd('startinsert!')
+        vim.cmd('if bufnr("$") == '..event.buf..' | startinsert | endif')
         vim.cmd('set cmdheight=1')
         vim.bo[event.buf].buflisted = false
         vim.keymap.set('n', 'q', '<cmd>close<cr>', { buffer = event.buf, silent = true })


### PR DESCRIPTION
Hey again @2KAbhishek,

There is a problem with binding `startinsert` to `TermOpen`: If a terminal gets opened in the background, it will always start Insert mode, even if you're not using said Terminal directly, which in this case is undesired and annoying. For example, I spotted mentioned issue while starting debug session in nvim-dap.

I fixed this by adding a branch that checks whether the currently open buffer is the `event.buf`.
I couldn't solve it from lua and had to use vimscript, probably because `vim.cmd()` adds a delay to the call.

This fixes the issue on my side but have in mind that I don't use termim.nvim directly, just few functions from your plugin that makes my config behave in similar way. So probably it would be nice if you could test it on your side.

Cheers