### PR TITLE
fix: use `vim.o.shell` instead of `vim.env.SHELL`

### DIFF
--- a/lua/termim/init.lua
+++ b/lua/termim/init.lua
@@ -19,7 +19,7 @@ end
 
 termim.open = function(command, split_dir, keep_open)
     if command == '' or command == nil then
-        command = vim.env.SHELL
+        command = vim.o.shell
     end
 
     if split_dir == '' or split_dir == nil then


### PR DESCRIPTION
fix command not found on windows