### PR TITLE
Make Terminals Ephemeral

### DIFF
--- a/lua/termim/init.lua
+++ b/lua/termim/init.lua
@@ -5,8 +5,12 @@ termim.close_augroup = 'termim_auto_close'
 termim.auto_close = function()
     vim.api.nvim_create_autocmd({ 'TermClose' }, {
         group = vim.api.nvim_create_augroup(termim.close_augroup, { clear = true }),
-        callback = function()
-            vim.cmd('quit')
+        callback = function(event)
+          vim.schedule(function()
+            if vim.api.nvim_buf_is_valid(event.buf) then
+              vim.api.nvim_buf_delete(event.buf, { force = true })
+            end
+          end)
         end,
     })
 end

--- a/plugin/termim.lua
+++ b/plugin/termim.lua
@@ -13,6 +13,7 @@ vim.api.nvim_create_autocmd({ 'TermOpen' }, {
         vim.cmd('startinsert!')
         vim.cmd('set cmdheight=1')
         vim.bo[event.buf].buflisted = false
+        vim.bo[event.buf].bufhidden = "wipe"
         vim.keymap.set('n', 'q', '<cmd>close<cr>', { buffer = event.buf, silent = true })
     end,
 })


### PR DESCRIPTION
## What does the PR do? (Required)

Since we are opening a new terminal every time, this change makes terminals truly ephemeral by deleting the hidden buffers instead of leaving them be.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [ ] I have followed the style guidelines of this project

## Evidence (Required)

Small recording  that shows the buffer goes away.

https://github.com/user-attachments/assets/537d08c9-9fed-4b87-b0f8-75a62cbf1dc7

